### PR TITLE
add IPV6 field to pingdom_check

### DIFF
--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -55,6 +55,11 @@ func resourcePingdomCheck() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"ipv6": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"responsetime_threshold": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -190,6 +195,7 @@ type commonCheckParams struct {
 	Hostname                 string
 	Resolution               int
 	Paused                   bool
+	IPv6                     bool
 	ResponseTimeThreshold    int
 	SendNotificationWhenDown int
 	NotifyAgainEvery         int
@@ -241,6 +247,10 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 
 	if v, ok := d.GetOk("paused"); ok {
 		checkParams.Paused = v.(bool)
+	}
+
+	if v, ok := d.GetOk("ipv6"); ok {
+		checkParams.IPv6 = v.(bool)
 	}
 
 	if v, ok := d.GetOk("resolution"); ok {
@@ -373,6 +383,7 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			Hostname:                 checkParams.Hostname,
 			Resolution:               checkParams.Resolution,
 			Paused:                   checkParams.Paused,
+			IPV6:                     checkParams.IPv6,
 			ResponseTimeThreshold:    checkParams.ResponseTimeThreshold,
 			SendNotificationWhenDown: checkParams.SendNotificationWhenDown,
 			NotifyAgainEvery:         checkParams.NotifyAgainEvery,
@@ -417,6 +428,7 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			Hostname:                 checkParams.Hostname,
 			Resolution:               checkParams.Resolution,
 			Paused:                   checkParams.Paused,
+			IPV6:                     checkParams.IPv6,
 			SendNotificationWhenDown: checkParams.SendNotificationWhenDown,
 			NotifyAgainEvery:         checkParams.NotifyAgainEvery,
 			NotifyWhenBackup:         checkParams.NotifyWhenBackup,
@@ -438,6 +450,7 @@ func checkForResource(d *schema.ResourceData) (pingdom.Check, error) {
 			NameServer:               checkParams.NameServer,
 			Resolution:               checkParams.Resolution,
 			Paused:                   checkParams.Paused,
+			IPV6:                     checkParams.IPv6,
 			SendNotificationWhenDown: checkParams.SendNotificationWhenDown,
 			NotifyAgainEvery:         checkParams.NotifyAgainEvery,
 			NotifyWhenBackup:         checkParams.NotifyWhenBackup,
@@ -545,6 +558,12 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
+	if ck.Status == "ipv6" {
+		if err := d.Set("ipv6", true); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	integids := schema.NewSet(
 		func(integrationId interface{}) int { return integrationId.(int) },
 		[]interface{}{},
@@ -619,6 +638,7 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		if err := d.Set("verify_certificate", ck.Type.HTTP.VerifyCertificate); err != nil {
 			return diag.FromErr(err)
 		}
+
 		if err := d.Set("ssl_down_days_before", ck.Type.HTTP.SSLDownDaysBefore); err != nil {
 			return diag.FromErr(err)
 		}

--- a/pingdom/resource_pingdom_check.go
+++ b/pingdom/resource_pingdom_check.go
@@ -557,13 +557,6 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 			return diag.FromErr(err)
 		}
 	}
-
-	if ck.Status == "ipv6" {
-		if err := d.Set("ipv6", true); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
 	integids := schema.NewSet(
 		func(integrationId interface{}) int { return integrationId.(int) },
 		[]interface{}{},
@@ -638,7 +631,6 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		if err := d.Set("verify_certificate", ck.Type.HTTP.VerifyCertificate); err != nil {
 			return diag.FromErr(err)
 		}
-
 		if err := d.Set("ssl_down_days_before", ck.Type.HTTP.SSLDownDaysBefore); err != nil {
 			return diag.FromErr(err)
 		}
@@ -651,6 +643,10 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		if err := d.Set("requestheaders", ck.Type.HTTP.RequestHeaders); err != nil {
 			return diag.FromErr(err)
 		}
+		if err := d.Set("ipv6", ck.IPv6); err != nil {
+			return diag.FromErr(err)
+		}
+
 	} else if ck.Type.TCP != nil {
 		if err := d.Set("type", checkTypeTcp); err != nil {
 			return diag.FromErr(err)
@@ -664,6 +660,10 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		if err := d.Set("stringtoexpect", ck.Type.TCP.StringToExpect); err != nil {
 			return diag.FromErr(err)
 		}
+
+		if err := d.Set("ipv6", ck.IPv6); err != nil {
+			return diag.FromErr(err)
+		}
 	} else if ck.Type.DNS != nil {
 		if err := d.Set("type", checkTypeDns); err != nil {
 			return diag.FromErr(err)
@@ -672,6 +672,9 @@ func resourcePingdomCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 			return diag.FromErr(err)
 		}
 		if err := d.Set("nameserver", ck.Type.DNS.NameServer); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("ipv6", ck.IPv6); err != nil {
 			return diag.FromErr(err)
 		}
 	} else {

--- a/pingdom/resource_pingdom_check_test.go
+++ b/pingdom/resource_pingdom_check_test.go
@@ -46,6 +46,7 @@ func TestAccResourcePingdomCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "probefilters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "userids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "teamids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6", "true"),
 				),
 			},
 			{
@@ -80,6 +81,7 @@ func TestAccResourcePingdomCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_message", "test"),
 					resource.TestCheckResourceAttrPair(resourceName, "userids.0", contactResourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "teamids.0", teamResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6", "true"),
 				),
 			},
 		},
@@ -356,6 +358,7 @@ resource "pingdom_check" "http" {
 	requestheaders = {
 		X-Test-Data = "test"
 	}
+	ipv6                     = false
 }
 `, name, name, name)
 }

--- a/pingdom/resource_pingdom_check_test.go
+++ b/pingdom/resource_pingdom_check_test.go
@@ -46,7 +46,7 @@ func TestAccResourcePingdomCheck_http(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "probefilters.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "userids.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "teamids.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
This adds the `IPV6` field for `pingdom_check` resource. It is already present in the CheckResponse struct in [go-pingdom](https://github.com/DrFaust92/go-pingdom/blob/master/pingdom/api_responses.go#L43) 

I built and tested the provider locally but wasn't able to run the tests, it keeps erroring with "no cookie received" even though I've exported the required ENVs `SOLARWINDS_ORG_ID`, `SOLARWINDS_USER`, `SOLARWINDS_PASSWD`, `PINGDOM_API_TOKEN`, `TF_ACC=1`