### PR TITLE
Make Solarwinds Credentials Optional (PingdomExt Client)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ examples/.terraform
 
 build/
 vendor/*
+
+/.vscode
+
+__debug_bin

--- a/pingdom/config.go
+++ b/pingdom/config.go
@@ -51,14 +51,17 @@ func (c *Config) Client() (*Clients, error) {
 	// 	return nil, err
 	// }
 
-	pingdomClientExt, err := pingdomext.NewClientWithConfig(pingdomext.ClientConfig{
-		Username: c.SolarwindsUser,
-		Password: c.SolarwindsPassword,
-		OrgID:    c.SolarwindsOrgID,
-	})
+	var pingdomClientExt *pingdomext.Client
+	if c.SolarwindsUser != "" {
+		pingdomClientExt, err = pingdomext.NewClientWithConfig(pingdomext.ClientConfig{
+			Username: c.SolarwindsUser,
+			Password: c.SolarwindsPassword,
+			OrgID:    c.SolarwindsOrgID,
+		})
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Clients{

--- a/pingdom/data_source_pingdom_integration.go
+++ b/pingdom/data_source_pingdom_integration.go
@@ -37,6 +37,11 @@ func dataSourcePingdomIntegration() *schema.Resource {
 
 func dataSourcePingdomIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
+
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
+
 	name := d.Get("name").(string)
 	integrations, err := client.Integrations.List()
 	log.Printf("[DEBUG] integrations : %v", integrations)

--- a/pingdom/data_source_pingdom_integrations.go
+++ b/pingdom/data_source_pingdom_integrations.go
@@ -30,6 +30,11 @@ func dataSourcePingdomIntegrations() *schema.Resource {
 
 func dataSourcePingdomIntegrationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
+
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
+
 	integrations, err := client.Integrations.List()
 	log.Printf("[DEBUG] integrations : %v", integrations)
 	if err != nil {

--- a/pingdom/resource_pingdom_integration.go
+++ b/pingdom/resource_pingdom_integration.go
@@ -88,6 +88,10 @@ func integrationForResource(d *schema.ResourceData, client *pingdomext.Client) (
 func resourcePingdomIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
 
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
+
 	integration, err := integrationForResource(d, client)
 	if err != nil {
 		return diag.FromErr(err)
@@ -109,6 +113,10 @@ func resourcePingdomIntegrationCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourcePingdomIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
+
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
 
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -134,6 +142,10 @@ func resourcePingdomIntegrationUpdate(ctx context.Context, d *schema.ResourceDat
 
 func resourcePingdomIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
+
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
 
 	integrations, err := client.Integrations.List()
 	if err != nil {
@@ -181,6 +193,11 @@ func resourcePingdomIntegrationRead(ctx context.Context, d *schema.ResourceData,
 
 func resourcePingdomIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*Clients).PingdomExt
+
+	if client == nil {
+		return diag.FromErr(fmt.Errorf("Client not correctly configured to use this resource"))
+	}
+
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.Errorf("Error retrieving id for resource: %s", err)


### PR DESCRIPTION
This allows an API token to be provided by itself without causing a cookie response error, due to lack of Solarwinds credentials.